### PR TITLE
✨: add new hook: `useStateMachine`

### DIFF
--- a/app/src/commonMain/kotlin/xyz/junerver/composehooks/example/useStateMachineExample.kt
+++ b/app/src/commonMain/kotlin/xyz/junerver/composehooks/example/useStateMachineExample.kt
@@ -1,0 +1,386 @@
+package xyz.junerver.composehooks.example
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import xyz.junerver.compose.hooks.useStateMachine
+import xyz.junerver.compose.hooks.stateGraphBuilder
+import xyz.junerver.composehooks.ui.component.TButton
+
+/*
+  Description: A Example to demonstrate how to use the useStateMachine Hook
+  Author: kk
+  Date: 2025/6/22-9:30
+  Email: kkneverlie@gmail.com
+  Version: v1.0
+*/
+
+// Define state enum
+enum class LoadingState {
+    IDLE,      // Idle state
+    LOADING,   // Loading
+    SUCCESS,   // Success
+    ERROR      // Error
+}
+
+// Define event enum
+enum class LoadingEvent {
+    START,     // Start loading
+    SUCCESS,   // Loading success
+    ERROR,     // Loading failed
+    RETRY      // Retry
+}
+
+@Composable
+fun UseStateMachineExample() {
+    // Define state transitions using DSL approach - cleaner and more readable
+    val transitions = stateGraphBuilder<LoadingState, LoadingEvent> {
+        state(LoadingState.IDLE) {
+            // From idle state can start loading
+            on(LoadingEvent.START) { transitionTo(LoadingState.LOADING) }
+        }
+
+        state(LoadingState.LOADING) {
+            // Loading can succeed or fail
+            on(LoadingEvent.SUCCESS) { transitionTo(LoadingState.SUCCESS) }
+            on(LoadingEvent.ERROR) { transitionTo(LoadingState.ERROR) }
+        }
+
+        state(LoadingState.SUCCESS) {
+            // Success state can reset, restart, or fail
+            on(LoadingEvent.START) { transitionTo(LoadingState.LOADING) }
+        }
+
+        state(LoadingState.ERROR) {
+            // Error state can reset or retry
+            on(LoadingEvent.RETRY) { transitionTo(LoadingState.LOADING) }
+        }
+    }
+
+    // Use state machine Hook with destructured assignment
+    val (
+        currentState,
+        canTransition,
+        transition,
+        history,
+        reset,
+        canGoBack,
+        goBack,
+        getAvailableEvents
+    ) = useStateMachine(
+        initialState = LoadingState.IDLE,
+        transitions = transitions,
+        maxHistorySize = 50
+    )
+
+    Surface {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Title
+            Text(
+                text = "State Machine Example - DSL Approach",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            // Current state display card
+            StateDisplayCard(currentState)
+
+            // State history records
+            HistoryCard(history)
+
+            // Control buttons section
+            ControlButtonsSection(
+                canTransition = canTransition,
+                transition = transition,
+                reset = reset,
+                canGoBack = canGoBack,
+                goBack = goBack
+            )
+
+            // Available events display
+            AvailableEventsCard(getAvailableEvents())
+        }
+    }
+}
+
+@Composable
+private fun StateDisplayCard(currentState: LoadingState) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = getStateColor(currentState).copy(alpha = 0.1f)
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .clip(CircleShape)
+                    .background(getStateColor(currentState))
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column {
+                Text(
+                    text = "Current state",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = getStateDisplayName(currentState),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryCard(history: List<LoadingState>) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Text(
+                text = "State history (${history.size} records)",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                history.takeLast(10).forEach { state ->
+                    Box(
+                        modifier = Modifier
+                            .size(12.dp)
+                            .clip(CircleShape)
+                            .background(getStateColor(state))
+                    )
+                }
+                if (history.size > 10) {
+                    Text(
+                        text = "...",
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ControlButtonsSection(
+    canTransition: (LoadingEvent) -> Boolean,
+    transition: (LoadingEvent) -> Unit,
+    reset: () -> Unit,
+    canGoBack: () -> Boolean,
+    goBack: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = "Control operations",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold
+            )
+
+            // State transition buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TButton(
+                    text = "Start",
+                    enabled = canTransition(LoadingEvent.START),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    transition(LoadingEvent.START)
+                }
+
+                TButton(
+                    text = "Success",
+                    enabled = canTransition(LoadingEvent.SUCCESS),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    transition(LoadingEvent.SUCCESS)
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TButton(
+                    text = "Error",
+                    enabled = canTransition(LoadingEvent.ERROR),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    transition(LoadingEvent.ERROR)
+                }
+
+                TButton(
+                    text = "Retry",
+                    enabled = canTransition(LoadingEvent.RETRY),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    transition(LoadingEvent.RETRY)
+                }
+            }
+
+            // Control operation buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TButton(
+                    text = "Reset",
+                    modifier = Modifier.weight(1f)
+                ) {
+                    reset()
+                }
+
+                TButton(
+                    text = "Go back",
+                    enabled = canGoBack(),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    goBack()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AvailableEventsCard(availableEvents: List<LoadingEvent>) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Text(
+                text = "Current available events (${availableEvents.size})",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (availableEvents.isEmpty()) {
+                Text(
+                    text = "No available events",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                // Use Column to ensure all events are visible
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    availableEvents.chunked(3).forEach { eventRow ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            eventRow.forEach { event ->
+                                Box(
+                                    modifier = Modifier
+                                        .background(
+                                            MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+                                            RoundedCornerShape(12.dp)
+                                        )
+                                        .padding(horizontal = 12.dp, vertical = 6.dp)
+                                ) {
+                                    Text(
+                                        text = getEventDisplayName(event),
+                                        fontSize = 12.sp,
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Helper function: Get state corresponding color
+private fun getStateColor(state: LoadingState): Color {
+    return when (state) {
+        LoadingState.IDLE -> Color.Gray
+        LoadingState.LOADING -> Color.Blue
+        LoadingState.SUCCESS -> Color.Green
+        LoadingState.ERROR -> Color.Red
+    }
+}
+
+// Helper function: Get state display name
+private fun getStateDisplayName(state: LoadingState): String {
+    return state.name
+}
+
+// Helper function: Get event display name
+private fun getEventDisplayName(event: LoadingEvent): String {
+    return event.name
+}
+

--- a/app/src/commonMain/kotlin/xyz/junerver/composehooks/route/routes.kt
+++ b/app/src/commonMain/kotlin/xyz/junerver/composehooks/route/routes.kt
@@ -33,6 +33,7 @@ import xyz.junerver.composehooks.example.UseRefExample
 import xyz.junerver.composehooks.example.UseResetStateExample
 import xyz.junerver.composehooks.example.UseSelectableExample
 import xyz.junerver.composehooks.example.UseStateExample
+import xyz.junerver.composehooks.example.UseStateMachineExample
 import xyz.junerver.composehooks.example.UseThrottleExample
 import xyz.junerver.composehooks.example.UseTimeoutExample
 import xyz.junerver.composehooks.example.UseTimestampExample
@@ -107,7 +108,8 @@ val routes = mapOf<String, @Composable () -> Unit>(
     "useUnmount" to { UseMountExample() },
     "useUpdate" to { UseUpdateExample() },
     "useUpdateEffect" to { UseUpdateEffectExample() },
-    "useSelectable" to { UseSelectableExample() }
+    "useSelectable" to { UseSelectableExample() },
+    "useStateMachine" to { UseStateMachineExample() }
 ) + androidRoutes
 
 val subRequestRoutes = mapOf<String, @Composable () -> Unit>(

--- a/hooks/src/commonMain/kotlin/xyz/junerver/compose/hooks/useStateMachine.kt
+++ b/hooks/src/commonMain/kotlin/xyz/junerver/compose/hooks/useStateMachine.kt
@@ -1,11 +1,13 @@
 package xyz.junerver.compose.hooks
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import kotlinx.collections.immutable.PersistentList
 
 /*
   Description: A Compose Hook for managing state machines
   Author: kk
-  Date: 2024/6/22-9:30
+  Date: 2025/6/22-9:30
   Email: kkneverlie@gmail.com
   Version: v1.0
 */
@@ -32,19 +34,19 @@ import androidx.compose.runtime.Composable
  * )
  *
  * // Or using the more readable DSL approach
- * val transitions = stateGraphBuilder<State, Event> {
+ * val transitions = buildStateMachineGraph<State, Event> {
  *     state(State.IDLE) {
- *         on(Event.START) { transitionTo(State.LOADING) }
+ *         Event.START transitionTo State.LOADING
  *     }
  *     state(State.LOADING) {
- *         on(Event.SUCCESS) { transitionTo(State.SUCCESS) }
- *         on(Event.ERROR) { transitionTo(State.ERROR) }
+ *         Event.SUCCESS transitionTo State.SUCCESS
+ *         Event.ERROR transitionTo State.ERROR
  *     }
  *     state(State.SUCCESS) {
- *         on(Event.RESET) { transitionTo(State.IDLE) }
+ *         Event.RESET transitionTo State.IDLE
  *     }
  *     state(State.ERROR) {
- *         on(Event.RESET) { transitionTo(State.IDLE) }
+ *         Event.RESET transitionTo State.IDLE
  *     }
  * }
  *
@@ -54,67 +56,52 @@ import androidx.compose.runtime.Composable
 @Composable
 fun <S : Any, E> useStateMachine(
     initialState: S,
-    transitions: Map<Pair<S, E>, S>,
+    transitions: Transition<S, E>,
     maxHistorySize: Int = 100
 ): StateMachineHolder<S, E> {
-    val (state, setState) = useGetState(initialState)
-    val history = useList<S>()
-
-    // Only add to history when state actually changes
-    useEffect(state) {
-        val currentState = state.value
-        if (history.isEmpty() || history.last() != currentState) {
-            history.add(currentState)
-            // Limit history size
-            if (history.size > maxHistorySize) {
-                history.removeAt(0)
-            }
-        }
-    }
+    val (currentState, setState) = useGetState(initialState)
+    val (undoState, setUndoState, resetUndoState, undo, _, canUndo, _) = useUndo(initialState)
 
     val canTransition = { event: E ->
-        transitions.containsKey(state.value to event)
+        transitions.containsKey(currentState.value to event)
     }
 
     val transition = { event: E ->
-        val currentState = state.value
-        val nextState = transitions[currentState to event]
+        val current = currentState.value
+        val nextState = transitions[current to event]
         if (nextState != null) {
             setState(nextState)
+            setUndoState(nextState)
         }
     }
 
     val reset = {
         setState(initialState)
-    }
-
-    val canGoBack = {
-        history.size > 1
+        resetUndoState(initialState)
     }
 
     val goBack = {
-        if (canGoBack()) {
-            // Remove current state
-            history.removeAt(history.size - 1)
-            // Get previous state
-            val previousState = history.last()
-            setState(previousState)
-        }
+        undo()
+        setState(undoState.value.present)
     }
 
     val getAvailableEvents = {
         transitions.keys
-            .filter { it.first == state.value }
+            .filter { it.first == currentState.value }
             .map { it.second }
     }
 
+    val history = useState {
+        undoState.value.past.add(undoState.value.present)
+    }
+
     return StateMachineHolder(
-        currentState = state.value,
+        currentState = currentState,
         canTransition = canTransition,
         transition = transition,
-        history = history.toList(), // Return immutable copy
+        history = history,
         reset = reset,
-        canGoBack = canGoBack,
+        canGoBack = canUndo,
         goBack = goBack,
         getAvailableEvents = getAvailableEvents
     )
@@ -123,7 +110,7 @@ fun <S : Any, E> useStateMachine(
 typealias Transition<S, E> = MutableMap<Pair<S, E>, S>
 
 /**
- * State graph builder function that provides a DSL for creating state transitions
+ * State machine graph builder function that provides a DSL for creating state transitions
  *
  * This function offers a more readable and maintainable way to define state machine transitions
  * compared to manually creating a Map. It uses a builder pattern with a DSL that clearly
@@ -134,34 +121,34 @@ typealias Transition<S, E> = MutableMap<Pair<S, E>, S>
  *
  * @example
  * ```kotlin
- * val transitions = stateGraphBuilder<MyState, MyEvent> {
+ * val transitions = buildStateMachineGraph<MyState, MyEvent> {
  *     state(MyState.INITIAL) {
- *         on(MyEvent.START) { transitionTo(MyState.PROCESSING) }
+ *         MyEvent.START transitionTo MyState.PROCESSING
  *     }
  *     state(MyState.PROCESSING) {
- *         on(MyEvent.COMPLETE) { transitionTo(MyState.DONE) }
- *         on(MyEvent.ERROR) { transitionTo(MyState.FAILED) }
+ *         MyEvent.COMPLETE transitionTo MyState.DONE
+ *         MyEvent.ERROR transitionTo MyState.FAILED
  *     }
  * }
  * ```
  */
-fun <S, E> stateGraphBuilder(
-    init: StateGraph<S, E>.() -> Unit
+fun <S : Any, E> buildStateMachineGraph(
+    init: StateMachineGraphScope<S, E>.() -> Unit
 ): Transition<S, E> {
-    val graph = StateGraph<S, E>()
+    val graph = StateMachineGraphScope<S, E>()
     graph.init()
     return graph.transitions
 }
 
 /**
- * State graph builder class that provides DSL for defining state machine transitions
+ * State machine graph builder scope that provides DSL for defining state machine transitions
  *
- * This class enables a fluent API for defining state transitions in a clear and readable way.
+ * This scope enables a fluent API for defining state transitions in a clear and readable way.
  * Each state can define multiple event handlers that specify which state to transition to.
  *
  * @param transitions Internal map storing the state transitions
  */
-class StateGraph<S, E>(val transitions: MutableMap<Pair<S, E>, S> = mutableMapOf()) {
+class StateMachineGraphScope<S, E>(val transitions: MutableMap<Pair<S, E>, S> = mutableMapOf()) {
 
     /**
      * Define a state and its possible transitions
@@ -171,63 +158,56 @@ class StateGraph<S, E>(val transitions: MutableMap<Pair<S, E>, S> = mutableMapOf
      */
     fun state(
         state: S,
-        descriptionBlock: Description<S, E>.() -> Unit
+        descriptionBlock: StateDescriptionScope<S, E>.() -> Unit
     ) {
-        val description = Description<S, E>()
+        val description = StateDescriptionScope<S, E>()
         descriptionBlock(description)
         description.eventMaps.forEach {
-            transitions.put(state to it.key, it.value)
+            transitions[state to it.key] = it.value
         }
     }
+}
+
+/**
+ * State description scope for defining event transitions within a state
+ *
+ * This scope provides an infix function style for defining transitions that reads naturally:
+ * `Event.START transitionTo State.LOADING`
+ *
+ * @param eventMaps Internal map storing event to state mappings
+ */
+class StateDescriptionScope<S, E>(val eventMaps: MutableMap<E, S> = mutableMapOf()) {
 
     /**
-     * Description class for defining event transitions within a state
+     * Infix function to define state transition for an event
      *
-     * @param eventMaps Internal map storing event to state mappings
+     * @receiver The event that triggers the transition
+     * @param state The target state to transition to
      */
-    class Description<S, E>(val eventMaps: MutableMap<E, S> = mutableMapOf<E, S>()) {
-
-        /**
-         * Define an event handler for the current state
-         *
-         * @param event The event to handle
-         * @param eventBlock Block that defines what to do when this event occurs
-         */
-        fun <E> on(event: E, eventBlock: E.() -> Unit) {
-            eventBlock(event)
-        }
-
-        /**
-         * Extension function to define state transition for an event
-         *
-         * @param state The target state to transition to
-         */
-        fun E.transitionTo(state: S) {
-            eventMaps.put(this, state)
-        }
+    infix fun E.transitionTo(state: S) {
+        eventMaps[this] = state
     }
-
 }
 
 /**
  * State machine holder containing current state and all control functions
  *
- * @property currentState Current state
+ * @property currentState Current state as a deferred read State
  * @property canTransition Check if the specified event transition can be executed
  * @property transition Execute state transition
- * @property history State history records (immutable list)
- * @property reset Reset to initial state
+ * @property history State history records as a deferred read State of PersistentList
+ * @property reset Reset to initial state and clear history
  * @property canGoBack Check if can go back to previous state
  * @property goBack Go back to previous state
  * @property getAvailableEvents Get list of available events for current state
  */
 data class StateMachineHolder<S : Any, E>(
-    val currentState: S,
+    val currentState: State<S>,
     val canTransition: (E) -> Boolean,
     val transition: (E) -> Unit,
-    val history: List<S>,
+    val history: State<PersistentList<S>>,
     val reset: () -> Unit,
-    val canGoBack: () -> Boolean,
+    val canGoBack: State<Boolean>,
     val goBack: () -> Unit,
     val getAvailableEvents: () -> List<E>
 )

--- a/hooks/src/commonMain/kotlin/xyz/junerver/compose/hooks/useStateMachine.kt
+++ b/hooks/src/commonMain/kotlin/xyz/junerver/compose/hooks/useStateMachine.kt
@@ -1,0 +1,233 @@
+package xyz.junerver.compose.hooks
+
+import androidx.compose.runtime.Composable
+
+/*
+  Description: A Compose Hook for managing state machines
+  Author: kk
+  Date: 2024/6/22-9:30
+  Email: kkneverlie@gmail.com
+  Version: v1.0
+*/
+
+/**
+ *
+ * @param initialState The initial state
+ * @param transitions State transition mapping table, defining transitions from (current state, event) to new state
+ * @param maxHistorySize Maximum length of history records, defaults to 100
+ * @return [StateMachineHolder] containing current state and control functions
+ *
+ * @example
+ * ```kotlin
+ * enum class State { IDLE, LOADING, SUCCESS, ERROR }
+ * enum class Event { START, SUCCESS, ERROR, RESET }
+ *
+ * // Using traditional Map approach
+ * val transitions = mapOf(
+ *     (State.IDLE to Event.START) to State.LOADING,
+ *     (State.LOADING to Event.SUCCESS) to State.SUCCESS,
+ *     (State.LOADING to Event.ERROR) to State.ERROR,
+ *     (State.SUCCESS to Event.RESET) to State.IDLE,
+ *     (State.ERROR to Event.RESET) to State.IDLE
+ * )
+ *
+ * // Or using the more readable DSL approach
+ * val transitions = stateGraphBuilder<State, Event> {
+ *     state(State.IDLE) {
+ *         on(Event.START) { transitionTo(State.LOADING) }
+ *     }
+ *     state(State.LOADING) {
+ *         on(Event.SUCCESS) { transitionTo(State.SUCCESS) }
+ *         on(Event.ERROR) { transitionTo(State.ERROR) }
+ *     }
+ *     state(State.SUCCESS) {
+ *         on(Event.RESET) { transitionTo(State.IDLE) }
+ *     }
+ *     state(State.ERROR) {
+ *         on(Event.RESET) { transitionTo(State.IDLE) }
+ *     }
+ * }
+ *
+ * val stateMachine = useStateMachine(State.IDLE, transitions)
+ * ```
+ */
+@Composable
+fun <S : Any, E> useStateMachine(
+    initialState: S,
+    transitions: Map<Pair<S, E>, S>,
+    maxHistorySize: Int = 100
+): StateMachineHolder<S, E> {
+    val (state, setState) = useGetState(initialState)
+    val history = useList<S>()
+
+    // Only add to history when state actually changes
+    useEffect(state) {
+        val currentState = state.value
+        if (history.isEmpty() || history.last() != currentState) {
+            history.add(currentState)
+            // Limit history size
+            if (history.size > maxHistorySize) {
+                history.removeAt(0)
+            }
+        }
+    }
+
+    val canTransition = { event: E ->
+        transitions.containsKey(state.value to event)
+    }
+
+    val transition = { event: E ->
+        val currentState = state.value
+        val nextState = transitions[currentState to event]
+        if (nextState != null) {
+            setState(nextState)
+        }
+    }
+
+    val reset = {
+        setState(initialState)
+    }
+
+    val canGoBack = {
+        history.size > 1
+    }
+
+    val goBack = {
+        if (canGoBack()) {
+            // Remove current state
+            history.removeAt(history.size - 1)
+            // Get previous state
+            val previousState = history.last()
+            setState(previousState)
+        }
+    }
+
+    val getAvailableEvents = {
+        transitions.keys
+            .filter { it.first == state.value }
+            .map { it.second }
+    }
+
+    return StateMachineHolder(
+        currentState = state.value,
+        canTransition = canTransition,
+        transition = transition,
+        history = history.toList(), // Return immutable copy
+        reset = reset,
+        canGoBack = canGoBack,
+        goBack = goBack,
+        getAvailableEvents = getAvailableEvents
+    )
+}
+
+typealias Transition<S, E> = MutableMap<Pair<S, E>, S>
+
+/**
+ * State graph builder function that provides a DSL for creating state transitions
+ *
+ * This function offers a more readable and maintainable way to define state machine transitions
+ * compared to manually creating a Map. It uses a builder pattern with a DSL that clearly
+ * expresses the relationship between states and events.
+ *
+ * @param init Configuration block for building the state graph
+ * @return A transition map that can be used with useStateMachine
+ *
+ * @example
+ * ```kotlin
+ * val transitions = stateGraphBuilder<MyState, MyEvent> {
+ *     state(MyState.INITIAL) {
+ *         on(MyEvent.START) { transitionTo(MyState.PROCESSING) }
+ *     }
+ *     state(MyState.PROCESSING) {
+ *         on(MyEvent.COMPLETE) { transitionTo(MyState.DONE) }
+ *         on(MyEvent.ERROR) { transitionTo(MyState.FAILED) }
+ *     }
+ * }
+ * ```
+ */
+fun <S, E> stateGraphBuilder(
+    init: StateGraph<S, E>.() -> Unit
+): Transition<S, E> {
+    val graph = StateGraph<S, E>()
+    graph.init()
+    return graph.transitions
+}
+
+/**
+ * State graph builder class that provides DSL for defining state machine transitions
+ *
+ * This class enables a fluent API for defining state transitions in a clear and readable way.
+ * Each state can define multiple event handlers that specify which state to transition to.
+ *
+ * @param transitions Internal map storing the state transitions
+ */
+class StateGraph<S, E>(val transitions: MutableMap<Pair<S, E>, S> = mutableMapOf()) {
+
+    /**
+     * Define a state and its possible transitions
+     *
+     * @param state The state to define transitions for
+     * @param descriptionBlock Block that defines the events and their target states
+     */
+    fun state(
+        state: S,
+        descriptionBlock: Description<S, E>.() -> Unit
+    ) {
+        val description = Description<S, E>()
+        descriptionBlock(description)
+        description.eventMaps.forEach {
+            transitions.put(state to it.key, it.value)
+        }
+    }
+
+    /**
+     * Description class for defining event transitions within a state
+     *
+     * @param eventMaps Internal map storing event to state mappings
+     */
+    class Description<S, E>(val eventMaps: MutableMap<E, S> = mutableMapOf<E, S>()) {
+
+        /**
+         * Define an event handler for the current state
+         *
+         * @param event The event to handle
+         * @param eventBlock Block that defines what to do when this event occurs
+         */
+        fun <E> on(event: E, eventBlock: E.() -> Unit) {
+            eventBlock(event)
+        }
+
+        /**
+         * Extension function to define state transition for an event
+         *
+         * @param state The target state to transition to
+         */
+        fun E.transitionTo(state: S) {
+            eventMaps.put(this, state)
+        }
+    }
+
+}
+
+/**
+ * State machine holder containing current state and all control functions
+ *
+ * @property currentState Current state
+ * @property canTransition Check if the specified event transition can be executed
+ * @property transition Execute state transition
+ * @property history State history records (immutable list)
+ * @property reset Reset to initial state
+ * @property canGoBack Check if can go back to previous state
+ * @property goBack Go back to previous state
+ * @property getAvailableEvents Get list of available events for current state
+ */
+data class StateMachineHolder<S : Any, E>(
+    val currentState: S,
+    val canTransition: (E) -> Boolean,
+    val transition: (E) -> Unit,
+    val history: List<S>,
+    val reset: () -> Unit,
+    val canGoBack: () -> Boolean,
+    val goBack: () -> Unit,
+    val getAvailableEvents: () -> List<E>
+)


### PR DESCRIPTION

This commit introduces a new Composable hook, `useStateMachine`, for managing state machines.

Key features:
- Defines state transitions using either a traditional Map or a more readable DSL approach.
- Provides functions to:
    - Check if a transition is possible.
    - Execute a transition.
    - Reset to the initial state.
    - Go back to the previous state.
    - Get available events for the current state.
- Tracks state history with a configurable maximum size.

A new example, `UseStateMachineExample`, demonstrates the usage of this hook with a loading state machine, showcasing the DSL approach for defining transitions.